### PR TITLE
Fix the bug in autograd example that sends wrong gradient backwards when computation graph doesn't resemble a tree

### DIFF
--- a/06_rnns/Autograd_Simple.ipynb
+++ b/06_rnns/Autograd_Simple.ipynb
@@ -115,21 +115,22 @@
     "            else:\n",
     "                self.grad += backward_grad\n",
     "        \n",
+    "        gradient_to_send = backward_grad if backward_grad is not None else 1\n",
     "        if self.creation_op == \"add\":\n",
-    "            # Simply send backward self.grad, since increasing either of these \n",
+    "            # Simply send backward backward_grad, since increasing either of these \n",
     "            # elements will increase the output by that same amount\n",
-    "            self.depends_on[0].backward(self.grad)\n",
-    "            self.depends_on[1].backward(self.grad)    \n",
+    "            self.depends_on[0].backward(gradient_to_send)\n",
+    "            self.depends_on[1].backward(gradient_to_send)    \n",
     "\n",
     "        if self.creation_op == \"mul\":\n",
     "\n",
     "            # Calculate the derivative with respect to the first element\n",
-    "            new = self.depends_on[1] * self.grad\n",
+    "            new = self.depends_on[1] * gradient_to_send\n",
     "            # Send backward the derivative with respect to that element\n",
     "            self.depends_on[0].backward(new.num)\n",
     "\n",
     "            # Calculate the derivative with respect to the second element\n",
-    "            new = self.depends_on[0] * self.grad\n",
+    "            new = self.depends_on[0] * gradient_to_send\n",
     "            # Send backward the derivative with respect to that element\n",
     "            self.depends_on[1].backward(new.num)"
    ]
@@ -155,6 +156,31 @@
     "c.backward()\n",
     "print(a.grad) # as expected\n",
     "print(b.grad) # as expected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "24\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = NumberWithGrad(3)\n",
+    "b = a * 4\n",
+    "c = b + 3\n",
+    "d = b * 5\n",
+    "e = c + d\n",
+    "\n",
+    "\n",
+    "e.backward()\n",
+    "print(a.grad)"
    ]
   },
   {


### PR DESCRIPTION
see https://leetcode.com/playground/UPrmL2r9. In this example e = 24a+3 and the gradient should be 24 instead of 28.

The issue is that when a `NumberWithGrad` object serves as the parent node of multiple operations, we just want to send the incoming gradient `backward_grad` recursively. The gradient of `b` is 1 from path `b->c->e`, and it's 5 from path `b->d->e`. We send gradient 1 to `a` for the first time and send gradient `1+5=6` for the second time, and that's why we see 28